### PR TITLE
Improved locker data (contains 1 breaking change)

### DIFF
--- a/app/Http/Controllers/LockerController.php
+++ b/app/Http/Controllers/LockerController.php
@@ -19,7 +19,7 @@ class LockerController extends Controller
      */
     public function index()
     {
-        $lockers = Locker::all();
+        $lockers = Locker::with('claims.client')->get();
         return LockerResource::collection($lockers);
     }
 
@@ -43,7 +43,10 @@ class LockerController extends Controller
      */
     public function show(string $lockerGuid)
     {
-        $locker = Locker::where('guid', $lockerGuid)->firstOrFail();
+        $locker = Locker::where('guid', $lockerGuid)
+            ->with('claims.client')
+            ->firstOrFail()
+        ;
         return new LockerResource($locker);
     }
 

--- a/app/Http/Resources/LockerClaimResource.php
+++ b/app/Http/Resources/LockerClaimResource.php
@@ -18,8 +18,13 @@ class LockerClaimResource extends JsonResource
             'id' => $this->id,
             'is_set_up' => $this->isSetUp(),
             'is_active' => $this->isActive(),
+            'attempts' => [
+                'failed' => $this->failed_attempts,
+                'left' => $this->attemptsLeft(),
+            ],
             'start_at' => $this->start_at,
             'end_at' => $this->end_at,
+            'client' => new ClientResource($this->whenLoaded('client')),
         ];
     }
 }

--- a/app/Http/Resources/LockerResource.php
+++ b/app/Http/Resources/LockerResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Http\Resources\ClientResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class LockerResource extends JsonResource
@@ -17,7 +18,9 @@ class LockerResource extends JsonResource
         return [
             'id' => $this->id,
             'guid' => $this->guid,
-            'is_currently_claimable' => $this->isCurrentlyClaimable(),
+            'active_claim' => optional($this->activeClaim(), function ($claim) {
+                return new LockerClaimResource($claim);
+            }),
         ];
     }
 }

--- a/app/Http/Resources/LockerResource.php
+++ b/app/Http/Resources/LockerResource.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Resources;
 
-use App\Http\Resources\ClientResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class LockerResource extends JsonResource

--- a/app/Models/Locker.php
+++ b/app/Models/Locker.php
@@ -11,6 +11,10 @@ class Locker extends Model
         'guid',
     ];
 
+    protected $with = [
+        'claims',
+    ];
+
     public function isUnlockable()
     {
         if (!$this->activeClaim()) {

--- a/app/Models/LockerClaim.php
+++ b/app/Models/LockerClaim.php
@@ -20,6 +20,11 @@ class LockerClaim extends Model
         'end_at',
     ];
 
+    protected $hidden = [
+        'setup_token',
+        'key_hash',
+    ];
+
     protected $dates = [
         'start_at',
         'end_at',


### PR DESCRIPTION
`is_currently_claimable` is replaced in favor of the new `active_claim` data, containing the currently active claim data, including client data.

For example:
```json
{
    "id": 1,
    "guid": "a5500b09-af28-33fc-a45b-558f2ce6188d",
    "active_claim": {
        "id": 25,
        "is_set_up": true,
        "is_active": true,
        "attempts": {
            "failed": 2,
            "left": 3
        },
        "start_at": "2020-01-16T10:53:50.000000Z",
        "end_at": "2020-02-01T00:00:00.000000Z",
        "client": {
            "id": 5,
            "email": "spencer.ivy@example.com"
        }
    }
}
```

```json
{
    "id": 2,
    "guid": "80ad1abb-316c-3aa7-b51b-4261771b0074",
    "active_claim": null
},
```

@BramMathijssen @puremonk 